### PR TITLE
Fix: use requestIdleCallback or setTimeout for Safari compatibility

### DIFF
--- a/src/context/token.tsx
+++ b/src/context/token.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useState } from 'react';
 import { useRetimer } from 'foxact/use-retimer';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
+import { requestIdleCallback } from 'foxact/request-idle-callback';
 
 const TokenContext = createContext<string | null>(null);
 export const useToken = () => useContext(TokenContext);
@@ -51,8 +52,6 @@ export const TokenProvider = ({ children }: React.PropsWithChildren) => {
   const retimer = useRetimer();
   const $setToken = useCallback((input: string | null) => {
     setToken(input);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Safari is not supported
-    const requestIdleCallback = window.requestIdleCallback || window.setTimeout;
     const timerId = requestIdleCallback(() => {
       if (input) {
         localStorage.setItem(TOKEN_NAME, input);

--- a/src/context/token.tsx
+++ b/src/context/token.tsx
@@ -51,14 +51,16 @@ export const TokenProvider = ({ children }: React.PropsWithChildren) => {
   const retimer = useRetimer();
   const $setToken = useCallback((input: string | null) => {
     setToken(input);
-
-    retimer(requestIdleCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Safari is not supported
+    const requestIdleCallback = window.requestIdleCallback || window.setTimeout;
+    const timerId = requestIdleCallback(() => {
       if (input) {
         localStorage.setItem(TOKEN_NAME, input);
       } else {
         localStorage.removeItem(TOKEN_NAME);
       }
-    }));
+    });
+    retimer(timerId);
   }, [retimer]);
 
   return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,14 +61,15 @@ const config = {
     static: {
       directory: path.join(__dirname, 'public')
     },
-    proxy: {
-      '/_sukka/api': {
+    proxy: [
+      {
+        context: ['/_sukka/api'],
         target: 'https://api.cloudflare.com',
         pathRewrite: { '^/_sukka/api': '' },
         secure: false,
         changeOrigin: true
       }
-    }
+    ]
   },
   module: {
     rules: [


### PR DESCRIPTION
1. **Fix: use requestIdleCallback or setTimeout for Safari compatibility**

https://developer.mozilla.org/zh-CN/docs/Web/API/Window/requestIdleCallback#浏览器兼容性


<img width="844" alt="image" src="https://github.com/user-attachments/assets/a513738f-1092-438b-b680-4bacace6b573">


---

2. **Fix: update proxy configuration to use array syntax**

<img width="971" alt="image" src="https://github.com/user-attachments/assets/68f2f9f5-835b-482b-9962-3607fe779331">
